### PR TITLE
relax slop dependency to >= 2.4.4

### DIFF
--- a/pry-remote.gemspec
+++ b/pry-remote.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_dependency "slop", "~> 3.0"
+  s.add_dependency "slop", ">= 2.4.4"
   s.add_dependency "pry", "~> 0.9.9"
 
   s.executables = ["pry-remote"]


### PR DESCRIPTION
pry-remote cannot work with the current pry release with a slop dependency of ~> 3.0 :(
