### PR TITLE
Params parsing fixes.

### DIFF
--- a/lib/pry-remote.rb
+++ b/lib/pry-remote.rb
@@ -189,9 +189,9 @@ module PryRemote
       params = Slop.parse args, :help => true do
         banner "#$PROGRAM_NAME [OPTIONS]"
 
-        on :h, :host, "Host of the server (#{DefaultHost})", true,
+        on :host=, "Host of the server (#{DefaultHost})", true,
            :default => DefaultHost
-        on :p, :port, "Port of the server (#{DefaultPort})", true,
+        on :p=, :port=, "Port of the server (#{DefaultPort})", true,
            :as => Integer, :default => DefaultPort
         on :c, :capture, "Captures $stdout and $stderr from the server (true)",
            :default => true

--- a/pry-remote.gemspec
+++ b/pry-remote.gemspec
@@ -4,7 +4,7 @@
 Gem::Specification.new do |s|
   s.name = "pry-remote"
 
-  s.version = "0.1.6"
+  s.version = "0.1.7"
 
   s.summary     = "Connect to Pry remotely"
   s.description = "Connect to Pry remotely using DRb"


### PR DESCRIPTION
I had to do this to keep the pry-remote command from using the url druby://:9876, which caused it to sporadically get a "Connection refused" error on the mac.

Possibly changes in the Slop gem caused these breakages.
