### PR TITLE
Workaround for #30

### DIFF
--- a/lib/pry-remote.rb
+++ b/lib/pry-remote.rb
@@ -198,7 +198,7 @@ module PryRemote
         on :f, "Disables loading of .pryrc to get input and "
       end
 
-      @host = params[:host]
+      @host = params[:host] || DefaultHost
       @port = params[:port]
 
       @capture = params[:capture]


### PR DESCRIPTION
This is just a quick hack to make it actually connect.

For some reason, I'm not seeing any meaningful parsing out of Slop.

@injekt ?  Any clues?

The simplest of steps can repro the issue and also demonstrate this fix:

```
ruby -rpry-remote -e pry_remote
```

And

```
pry-remote
```

Also, I was seeing some problems in the colorization, but that's a different Issue.
