### PR TITLE
Add how to run with custom port and host on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,12 @@ You can then connect yourself using ``pry-remote``:
     ]
     pry(#<Foo:0x00000001efb3b0>):3> ^D
 
+## Specifying port and host
+
+Server:
+
+```binding.remote_pry("11.111.0.165", 4000)```
+
+Client:
+
+```pry-remote -s 11.111.0.165 -p 4000 ```


### PR DESCRIPTION
It'd be nice if the readme had a short description of how to connect to custom port and server, like described in https://medium.com/@Nauman/pry-remote-missing-readme-40d28f2b946

It saves the effort of looking into the code itself