### PR TITLE
Upgrading Slop Gem dependency

### DIFF
--- a/pry-remote.gemspec
+++ b/pry-remote.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_dependency "slop", "~> 3.0"
+  s.add_dependency "slop", "~> 4.0"
   s.add_dependency "pry",  "~> 0.9"
 
   s.executables = ["pry-remote"]


### PR DESCRIPTION
Upgrade slop gem on pry-remote to version 4ish.

Using pry-remote on projects like Gruf Framework is
throwing errors because slop gem is really old and not
compatible. We upgraded the version in one fork that
I created and it works.

Updating the gem reference on pry-remote.gemspec file
bumping the version to ~>4.0