### PR TITLE
Add drb gem as dependency

### DIFF
--- a/pry-remote.gemspec
+++ b/pry-remote.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
+  s.add_dependency "drb"
   s.add_dependency "slop", "~> 3.0"
   s.add_dependency "pry",  "~> 0.9"
 


### PR DESCRIPTION
drb has been bundled as a gem, and will be removed from the stdlib from ruby 3.4.0

This patch will fix following warning with Ruby 3.3.0
> warning: drb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add drb to your Gemfile or gemspec. Also contact author of pry-remote-0.1.8 to add drb into its gemspec.